### PR TITLE
修复SYNPROXY模式下，无法回复real service ack报文

### DIFF
--- a/core/lb_proto_tcp.c
+++ b/core/lb_proto_tcp.c
@@ -536,8 +536,7 @@ tcp_fullnat_recv_client(struct rte_mbuf *m, struct ipv4_hdr *iph,
         (!SYN(th) && ACK(th) && !RST(th) && !FIN(th))) {
         TCP_PRINT(IPv4_TCP_FMT " [SYNPROXY SYN_SENT DROP]\n",
                   IPv4_TCP_ARG(iph, th));
-        rte_pktmbuf_free(conn->proxy.ack_mbuf);
-        conn->proxy.ack_mbuf = m;
+        rte_pktmbuf_free(m);
         return 0;
     }
 

--- a/core/lb_synproxy.c
+++ b/core/lb_synproxy.c
@@ -418,6 +418,8 @@ synproxy_recv_client_ack(struct rte_mbuf *m, struct ipv4_hdr *iph,
 
             conn->proxy.isn = rte_be_to_cpu_32(th->recv_ack) - 1;
 
+            conn->proxy.ack_mbuf = m;
+
             synproxy_sent_backend_syn(m, iph, th, conn, &opts, dev);
         } else {
             rte_pktmbuf_free(m);


### PR DESCRIPTION
在 `lb_proto_tcp.c` 的 `tcp_fullnat_recv_client()` 函数中：

```c
if (conn == NULL) {
    if (synproxy_recv_client_ack(...) == 0) {
        return 0;  // ← 这里直接返回，导致后面的 ACK 缓存逻辑未执行
    }
}
```

这导致 `conn->proxy.ack_mbuf` 始终为 NULL，当收到后端 SYN-ACK 时，无法正常回复 ACK。